### PR TITLE
Record timings using Data.Time.Clock.System

### DIFF
--- a/fused-effects-profile.cabal
+++ b/fused-effects-profile.cabal
@@ -50,5 +50,6 @@ library
     , prettyprinter ^>= 1.5
     , prettyprinter-ansi-terminal ^>= 1.1
     , text ^>= 1.2
+    , time ^>= 1.9
     , transformers >= 0.4 && < 0.6
     , unordered-containers ^>= 0.2

--- a/fused-effects-profile.cabal
+++ b/fused-effects-profile.cabal
@@ -50,6 +50,5 @@ library
     , prettyprinter ^>= 1.5
     , prettyprinter-ansi-terminal ^>= 1.1
     , text ^>= 1.2
-    , time ^>= 1.9
     , transformers >= 0.4 && < 0.6
     , unordered-containers ^>= 0.2

--- a/src/Control/Carrier/Profile/Flat.hs
+++ b/src/Control/Carrier/Profile/Flat.hs
@@ -31,6 +31,7 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Time.Clock
+import Data.Time.Clock.System
 import Data.Timing
 import Prelude hiding (lookup, sum)
 
@@ -54,9 +55,9 @@ newtype ProfileC m a = ProfileC { runProfileC :: WriterC Timings m a }
 instance Has (Lift IO) sig m => Algebra (Profile :+: sig) (ProfileC m) where
   alg hdl sig ctx = case sig of
     L (Measure l m) -> do
-      start <- sendM getCurrentTime
+      start <- systemToUTCTime <$> sendM getSystemTime
       (sub, a) <- ProfileC (listen @Timings (runProfileC (hdl (m <$ ctx))))
-      end <- sendM getCurrentTime
+      end <- systemToUTCTime <$> sendM getSystemTime
       let t = lookup l sub
       -- subtract re-entrant measurements so we don’t count them twice
       a <$ ProfileC (tell (timing l ((end `diffUTCTime` start) - maybe 0 sum t)))

--- a/src/Control/Carrier/Profile/Flat.hs
+++ b/src/Control/Carrier/Profile/Flat.hs
@@ -30,8 +30,6 @@ import Control.Monad (MonadPlus)
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
-import Data.Time.Clock
-import Data.Time.Clock.System
 import Data.Timing
 import Prelude hiding (lookup, sum)
 
@@ -55,12 +53,12 @@ newtype ProfileC m a = ProfileC { runProfileC :: WriterC Timings m a }
 instance Has (Lift IO) sig m => Algebra (Profile :+: sig) (ProfileC m) where
   alg hdl sig ctx = case sig of
     L (Measure l m) -> do
-      start <- systemToUTCTime <$> sendM getSystemTime
+      start <- now
       (sub, a) <- ProfileC (listen @Timings (runProfileC (hdl (m <$ ctx))))
-      end <- systemToUTCTime <$> sendM getSystemTime
+      duration <- since start <$> now
       let t = lookup l sub
       -- subtract re-entrant measurements so we don’t count them twice
-      a <$ ProfileC (tell (timing l ((end `diffUTCTime` start) - maybe 0 sum t)))
+      a <$ ProfileC (tell (timing l (duration - maybe 0 sum t)))
     R other         -> ProfileC (alg (runProfileC . hdl) (R other) ctx)
     where
     timing l t = singleton l (Timing t t t 1 mempty)

--- a/src/Control/Carrier/Profile/Flat.hs
+++ b/src/Control/Carrier/Profile/Flat.hs
@@ -30,9 +30,10 @@ import Control.Monad (MonadPlus)
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
-import Data.Time.Clock
+import Data.Fixed (Fixed(..))
 import Data.Timing
 import Prelude hiding (lookup, sum)
+import System.CPUTime
 
 runProfile :: Applicative m => ProfileC m a -> m (Timings, a)
 runProfile = runWriter (curry pure) . runProfileC
@@ -54,12 +55,12 @@ newtype ProfileC m a = ProfileC { runProfileC :: WriterC Timings m a }
 instance Has (Lift IO) sig m => Algebra (Profile :+: sig) (ProfileC m) where
   alg hdl sig ctx = case sig of
     L (Measure l m) -> do
-      start <- sendM getCurrentTime
+      start <- sendM getCPUTime
       (sub, a) <- ProfileC (listen @Timings (runProfileC (hdl (m <$ ctx))))
-      end <- sendM getCurrentTime
+      end <- sendM getCPUTime
       let t = lookup l sub
       -- subtract re-entrant measurements so we don’t count them twice
-      a <$ ProfileC (tell (timing l ((end `diffUTCTime` start) - maybe 0 sum t)))
+      a <$ ProfileC (tell (timing l (MkFixed (end - start) - maybe 0 sum t)))
     R other         -> ProfileC (alg (runProfileC . hdl) (R other) ctx)
     where
     timing l t = singleton l (Timing t t t 1 mempty)

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -116,7 +116,7 @@ instance Monoid Duration where
   mempty = Duration (MkSystemTime 0 0)
 
 durationToFrac :: Fractional a => Duration -> a
-durationToFrac (Duration (MkSystemTime s ns)) = realToFrac s + realToFrac ns * 10^^(-9 :: Integer)
+durationToFrac (Duration (MkSystemTime s ns)) = realToFrac s + realToFrac ns * 10^^(-12 :: Integer)
 
 now :: Has (Lift IO) sig m => m Instant
 now = Instant <$> sendIO getSystemTime

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -14,6 +14,7 @@ module Data.Timing
 , renderTimings
 , reportTimings
 , Instant(..)
+, since
 , Duration(..)
 , now
 ) where
@@ -98,6 +99,9 @@ reportTimings = sendM . renderIO stderr . layoutPretty defaultLayoutOptions . (<
 
 
 newtype Instant = Instant { getInstant :: SystemTime }
+
+since :: Instant -> Instant -> Duration
+since (Instant (MkSystemTime bs bns)) (Instant (MkSystemTime as ans)) = Duration (MkSystemTime (as - bs) (ans - bns))
 
 
 newtype Duration = Duration { getDuration :: SystemTime }

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -99,3 +99,6 @@ newtype Duration = Duration { getDuration :: SystemTime }
 
 instance Semigroup Duration where
   Duration (MkSystemTime s1 ns1) <> Duration (MkSystemTime s2 ns2) = Duration (MkSystemTime (s1 + s2) (ns1 + ns2))
+
+instance Monoid Duration where
+  mempty = Duration (MkSystemTime 0 0)

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -13,6 +13,7 @@ module Data.Timing
 , lookup
 , renderTimings
 , reportTimings
+, Duration(..)
 ) where
 
 import           Control.Effect.Lift
@@ -24,6 +25,7 @@ import           Data.Text (Text, pack)
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
 import           Data.Time.Clock
+import           Data.Time.Clock.System
 import           Numeric (showFFloat)
 import           Prelude hiding (lookup)
 import           System.IO (stderr)
@@ -91,3 +93,6 @@ renderTimings (Timings ts) = vsep (map go (sortOn (Down . mean . snd) (HashMap.t
 
 reportTimings :: Has (Lift IO) sig m => Timings -> m ()
 reportTimings = sendM . renderIO stderr . layoutPretty defaultLayoutOptions . (<> line) . renderTimings
+
+
+newtype Duration = Duration { getDuration :: SystemTime }

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -116,7 +116,7 @@ instance Monoid Duration where
   mempty = Duration (MkSystemTime 0 0)
 
 durationToFrac :: Fractional a => Duration -> a
-durationToFrac (Duration (MkSystemTime s ns)) = realToFrac s + realToFrac ns * 10^^(-12)
+durationToFrac (Duration (MkSystemTime s ns)) = realToFrac s + realToFrac ns * 10^^(-12 :: Integer)
 
 now :: Has (Lift IO) sig m => m Instant
 now = Instant <$> sendIO getSystemTime

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -116,7 +116,7 @@ instance Monoid Duration where
   mempty = Duration (MkSystemTime 0 0)
 
 durationToFrac :: Fractional a => Duration -> a
-durationToFrac (Duration (MkSystemTime s ns)) = realToFrac s + realToFrac ns * 10^^(-12 :: Integer)
+durationToFrac (Duration (MkSystemTime s ns)) = realToFrac s + realToFrac ns * 10^^(-9 :: Integer)
 
 now :: Has (Lift IO) sig m => m Instant
 now = Instant <$> sendIO getSystemTime

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -16,7 +16,6 @@ module Data.Timing
 , Instant(..)
 , since
 , Duration(..)
-, durationToFrac
 , now
 ) where
 
@@ -114,9 +113,6 @@ instance Semigroup Duration where
 
 instance Monoid Duration where
   mempty = Duration (MkSystemTime 0 0)
-
-durationToFrac :: Fractional a => Duration -> a
-durationToFrac (Duration (MkSystemTime s ns)) = realToFrac s + realToFrac ns * 10^^(-12)
 
 now :: Has (Lift IO) sig m => m Instant
 now = Instant <$> sendIO getSystemTime

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -103,6 +103,7 @@ newtype Instant = Instant { getInstant :: SystemTime }
 
 since :: Instant -> Instant -> Duration
 since (Instant (MkSystemTime bs bns)) (Instant (MkSystemTime as ans)) = Duration (MkSystemTime (as - bs) (ans - bns))
+{-# INLINABLE since #-}
 
 
 newtype Duration = Duration { getDuration :: SystemTime }

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -17,21 +17,21 @@ module Data.Timing
 
 import           Control.Effect.Lift
 import           Data.Coerce
+import           Data.Fixed (Pico)
 import qualified Data.HashMap.Strict as HashMap
 import           Data.List (sortOn)
 import           Data.Ord (Down(..))
 import           Data.Text (Text, pack)
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
-import           Data.Time.Clock
 import           Numeric (showFFloat)
 import           Prelude hiding (lookup)
 import           System.IO (stderr)
 
 data Timing = Timing
-  { sum   :: !NominalDiffTime
-  , min'  :: !NominalDiffTime
-  , max'  :: !NominalDiffTime
+  { sum   :: !Pico
+  , min'  :: !Pico
+  , max'  :: !Pico
   , count :: {-# UNPACK #-} !Int
   , sub   :: !Timings
   }
@@ -56,7 +56,7 @@ renderTiming t@Timing{ min', max', sub } = table (map go fields) <> if null (unT
     go (k, v) = k <> colon <+> v
     prettyMS = (<> annotate (colorDull White) "ms") . pretty . ($ "") . showFFloat @Double (Just 3) . (* 1000) . realToFrac
 
-mean :: Timing -> NominalDiffTime
+mean :: Timing -> Pico
 mean Timing{ sum, count } = sum / fromIntegral count
 {-# INLINE mean #-}
 

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -13,6 +13,7 @@ module Data.Timing
 , lookup
 , renderTimings
 , reportTimings
+, Instant(..)
 , Duration(..)
 , now
 ) where
@@ -96,6 +97,9 @@ reportTimings :: Has (Lift IO) sig m => Timings -> m ()
 reportTimings = sendM . renderIO stderr . layoutPretty defaultLayoutOptions . (<> line) . renderTimings
 
 
+newtype Instant = Instant { getInstant :: SystemTime }
+
+
 newtype Duration = Duration { getDuration :: SystemTime }
 
 instance Semigroup Duration where
@@ -104,5 +108,5 @@ instance Semigroup Duration where
 instance Monoid Duration where
   mempty = Duration (MkSystemTime 0 0)
 
-now :: Has (Lift IO) sig m => m Duration
-now = Duration <$> sendIO getSystemTime
+now :: Has (Lift IO) sig m => m Instant
+now = Instant <$> sendIO getSystemTime

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -29,16 +29,15 @@ import           Data.Ord (Down(..))
 import           Data.Text (Text, pack)
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
-import           Data.Time.Clock
 import           Data.Time.Clock.System
 import           Numeric (showFFloat)
 import           Prelude hiding (lookup)
 import           System.IO (stderr)
 
 data Timing = Timing
-  { sum   :: !NominalDiffTime
-  , min'  :: !NominalDiffTime
-  , max'  :: !NominalDiffTime
+  { sum   :: !Duration
+  , min'  :: !Duration
+  , max'  :: !Duration
   , count :: {-# UNPACK #-} !Int
   , sub   :: !Timings
   }
@@ -63,7 +62,7 @@ renderTiming t@Timing{ min', max', sub } = table (map go fields) <> if null (unT
     go (k, v) = k <> colon <+> v
     prettyMS = (<> annotate (colorDull White) "ms") . pretty . ($ "") . showFFloat @Double (Just 3) . (* 1000) . realToFrac
 
-mean :: Timing -> NominalDiffTime
+mean :: Timing -> Duration
 mean Timing{ sum, count } = sum / fromIntegral count
 {-# INLINE mean #-}
 
@@ -104,7 +103,7 @@ newtype Instant = Instant { getInstant :: SystemTime }
   deriving (Eq, Ord, Show)
 
 since :: Instant -> Instant -> Duration
-since (Instant (MkSystemTime bs bns)) (Instant (MkSystemTime as ans)) = Duration (MkSystemTime (as - bs) (ans - bns))
+since (Instant (MkSystemTime bs bns)) (Instant (MkSystemTime as ans)) = Duration (realToFrac (as - bs) + MkFixed (fromIntegral (ans - bns)))
 {-# INLINABLE since #-}
 
 

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -96,3 +96,6 @@ reportTimings = sendM . renderIO stderr . layoutPretty defaultLayoutOptions . (<
 
 
 newtype Duration = Duration { getDuration :: SystemTime }
+
+instance Semigroup Duration where
+  Duration (MkSystemTime s1 ns1) <> Duration (MkSystemTime s2 ns2) = Duration (MkSystemTime (s1 + s2) (ns1 + ns2))

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -116,7 +116,7 @@ instance Monoid Duration where
   mempty = Duration (MkSystemTime 0 0)
 
 durationToFrac :: Fractional a => Duration -> a
-durationToFrac (Duration (MkSystemTime s ns)) = realToFrac s + realToFrac ns * 10^^(-12 :: Integer)
+durationToFrac (Duration (MkSystemTime s ns)) = realToFrac s + realToFrac ns * 10^^(-12)
 
 now :: Has (Lift IO) sig m => m Instant
 now = Instant <$> sendIO getSystemTime

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -99,12 +99,14 @@ reportTimings = sendM . renderIO stderr . layoutPretty defaultLayoutOptions . (<
 
 
 newtype Instant = Instant { getInstant :: SystemTime }
+  deriving (Eq, Ord, Show)
 
 since :: Instant -> Instant -> Duration
 since (Instant (MkSystemTime bs bns)) (Instant (MkSystemTime as ans)) = Duration (MkSystemTime (as - bs) (ans - bns))
 
 
 newtype Duration = Duration { getDuration :: SystemTime }
+  deriving (Eq, Ord, Show)
 
 instance Semigroup Duration where
   Duration (MkSystemTime s1 ns1) <> Duration (MkSystemTime s2 ns2) = Duration (MkSystemTime (s1 + s2) (ns1 + ns2))

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -103,7 +103,7 @@ newtype Instant = Instant { getInstant :: SystemTime }
   deriving (Eq, Ord, Show)
 
 since :: Instant -> Instant -> Duration
-since (Instant (MkSystemTime bs bns)) (Instant (MkSystemTime as ans)) = Duration (realToFrac (as - bs) + MkFixed (fromIntegral (ans - bns)))
+since (Instant (MkSystemTime bs bns)) (Instant (MkSystemTime as ans)) = Duration (realToFrac (as - bs) + MkFixed (fromIntegral ans - fromIntegral bns))
 {-# INLINABLE since #-}
 
 

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
@@ -21,6 +22,7 @@ module Data.Timing
 
 import           Control.Effect.Lift
 import           Data.Coerce
+import           Data.Fixed
 import qualified Data.HashMap.Strict as HashMap
 import           Data.List (sortOn)
 import           Data.Ord (Down(..))
@@ -106,14 +108,8 @@ since (Instant (MkSystemTime bs bns)) (Instant (MkSystemTime as ans)) = Duration
 {-# INLINABLE since #-}
 
 
-newtype Duration = Duration { getDuration :: SystemTime }
-  deriving (Eq, Ord, Show)
-
-instance Semigroup Duration where
-  Duration (MkSystemTime s1 ns1) <> Duration (MkSystemTime s2 ns2) = Duration (MkSystemTime (s1 + s2) (ns1 + ns2))
-
-instance Monoid Duration where
-  mempty = Duration (MkSystemTime 0 0)
+newtype Duration = Duration { getDuration :: Nano }
+  deriving (Eq, Fractional, Num, Ord, Real, Show)
 
 now :: Has (Lift IO) sig m => m Instant
 now = Instant <$> sendIO getSystemTime

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -116,3 +116,4 @@ instance Monoid Duration where
 
 now :: Has (Lift IO) sig m => m Instant
 now = Instant <$> sendIO getSystemTime
+{-# INLINABLE now #-}

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -17,21 +17,21 @@ module Data.Timing
 
 import           Control.Effect.Lift
 import           Data.Coerce
-import           Data.Fixed (Pico)
 import qualified Data.HashMap.Strict as HashMap
 import           Data.List (sortOn)
 import           Data.Ord (Down(..))
 import           Data.Text (Text, pack)
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
+import           Data.Time.Clock
 import           Numeric (showFFloat)
 import           Prelude hiding (lookup)
 import           System.IO (stderr)
 
 data Timing = Timing
-  { sum   :: !Pico
-  , min'  :: !Pico
-  , max'  :: !Pico
+  { sum   :: !NominalDiffTime
+  , min'  :: !NominalDiffTime
+  , max'  :: !NominalDiffTime
   , count :: {-# UNPACK #-} !Int
   , sub   :: !Timings
   }
@@ -56,7 +56,7 @@ renderTiming t@Timing{ min', max', sub } = table (map go fields) <> if null (unT
     go (k, v) = k <> colon <+> v
     prettyMS = (<> annotate (colorDull White) "ms") . pretty . ($ "") . showFFloat @Double (Just 3) . (* 1000) . realToFrac
 
-mean :: Timing -> Pico
+mean :: Timing -> NominalDiffTime
 mean Timing{ sum, count } = sum / fromIntegral count
 {-# INLINE mean #-}
 

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -16,6 +16,7 @@ module Data.Timing
 , Instant(..)
 , since
 , Duration(..)
+, durationToFrac
 , now
 ) where
 
@@ -113,6 +114,9 @@ instance Semigroup Duration where
 
 instance Monoid Duration where
   mempty = Duration (MkSystemTime 0 0)
+
+durationToFrac :: Fractional a => Duration -> a
+durationToFrac (Duration (MkSystemTime s ns)) = realToFrac s + realToFrac ns * 10^^(-12)
 
 now :: Has (Lift IO) sig m => m Instant
 now = Instant <$> sendIO getSystemTime

--- a/src/Data/Timing.hs
+++ b/src/Data/Timing.hs
@@ -14,6 +14,7 @@ module Data.Timing
 , renderTimings
 , reportTimings
 , Duration(..)
+, now
 ) where
 
 import           Control.Effect.Lift
@@ -102,3 +103,6 @@ instance Semigroup Duration where
 
 instance Monoid Duration where
   mempty = Duration (MkSystemTime 0 0)
+
+now :: Has (Lift IO) sig m => m Duration
+now = Duration <$> sendIO getSystemTime


### PR DESCRIPTION
We don’t need the extra layers of interpretation atop timings; time zones, etc., are surplus to requirements.

So, `System.CPUTime` suffices.

This PR:

- [x] ~~Records timings using `System.CPUTime`~~
- [x] ~~🔥s the dependency on `time`.~~
- [x] Reduces overheads substantially.
- [x] Records timings using `Data.Time.Clock.System`.
- [x] Depends on #2.