### PR TITLE
Add fused-effects-time; reframe as a suite of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 Profiling using `fused-effects`.
 
 [`fused-effects-profile`]: https://github.com/fused-effects/fused-effects-profile/tree/master/fused-effects-profile
+
+
+## [`fused-effects-time`][]
+
+Timing using `fused-effects`.
+
+[`fused-effects-time`]: https://github.com/fused-effects/fused-effects-profile/tree/master/fused-effects-time

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,2 @@
-packages: fused-effects-profile
+packages:
+  fused-effects-profile

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,3 @@
 packages:
   fused-effects-profile
+  fused-effects-time

--- a/fused-effects-profile/fused-effects-profile.cabal
+++ b/fused-effects-profile/fused-effects-profile.cabal
@@ -14,6 +14,7 @@ copyright:           2020 Rob Rix
 category:            System
 extra-source-files:
   CHANGELOG.md
+  README.md
 
 common common
   default-language: Haskell2010

--- a/fused-effects-profile/fused-effects-profile.cabal
+++ b/fused-effects-profile/fused-effects-profile.cabal
@@ -4,7 +4,7 @@ name:                fused-effects-profile
 version:             0.0.0.0
 synopsis:            Profiling without recompiling, via fused-effects.
 description:         Profiling for Haskell programs without recompiling, via fused-effects.
-homepage:            https://github.com/fused-effects/fused-effects-profile
+homepage:            https://github.com/fused-effects/fused-effects-profile/tree/master/fused-effects-profile
 bug-reports:         https://github.com/fused-effects/fused-effects-profile/issues
 license:             BSD-3-Clause
 license-file:        LICENSE

--- a/fused-effects-profile/fused-effects-profile.cabal
+++ b/fused-effects-profile/fused-effects-profile.cabal
@@ -48,6 +48,7 @@ library
   build-depends:
     , base >= 4.12 && < 5
     , fused-effects ^>= 1.1
+    , fused-effects-time ^>= 0
     , prettyprinter ^>= 1.5
     , prettyprinter-ansi-terminal ^>= 1.1
     , text ^>= 1.2

--- a/fused-effects-profile/fused-effects-profile.cabal
+++ b/fused-effects-profile/fused-effects-profile.cabal
@@ -11,7 +11,7 @@ license-file:        LICENSE
 author:              Rob Rix
 maintainer:          rob.rix@me.com
 copyright:           2020 Rob Rix
-category:            Development
+category:            System
 extra-source-files:
   CHANGELOG.md
 

--- a/fused-effects-profile/src/Control/Carrier/Profile/Flat.hs
+++ b/fused-effects-profile/src/Control/Carrier/Profile/Flat.hs
@@ -26,6 +26,7 @@ import Control.Applicative (Alternative)
 import Control.Carrier.Lift
 import Control.Carrier.Writer.Church
 import Control.Effect.Profile
+import Control.Effect.Time
 import Control.Monad (MonadPlus)
 import Control.Monad.Fix
 import Control.Monad.IO.Class
@@ -50,7 +51,7 @@ execProfile = execWriter . runProfileC
 newtype ProfileC m a = ProfileC { runProfileC :: WriterC Timings m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
-instance Has (Lift IO) sig m => Algebra (Profile :+: sig) (ProfileC m) where
+instance Has (Time Instant) sig m => Algebra (Profile :+: sig) (ProfileC m) where
   alg hdl sig ctx = case sig of
     L (Measure l m) -> do
       start <- now

--- a/fused-effects-profile/src/Control/Carrier/Profile/Flat.hs
+++ b/fused-effects-profile/src/Control/Carrier/Profile/Flat.hs
@@ -54,7 +54,7 @@ newtype ProfileC m a = ProfileC { runProfileC :: WriterC Timings m a }
 instance Has (Time Instant) sig m => Algebra (Profile :+: sig) (ProfileC m) where
   alg hdl sig ctx = case sig of
     L (Measure l m) -> do
-      (duration, (sub, a)) <- time (ProfileC (listen @Timings (runProfileC (hdl (m <$ ctx)))))
+      (sub, (duration, a)) <- ProfileC (listen @Timings (runProfileC (time (hdl (m <$ ctx)))))
       let t = lookup l sub
       -- subtract re-entrant measurements so we don’t count them twice
       a <$ ProfileC (tell (timing l (maybe duration ((duration -) . sum) t)))

--- a/fused-effects-profile/src/Control/Carrier/Profile/Tree.hs
+++ b/fused-effects-profile/src/Control/Carrier/Profile/Tree.hs
@@ -21,6 +21,7 @@ import Control.Applicative (Alternative)
 import Control.Carrier.Lift
 import Control.Carrier.Writer.Church
 import Control.Effect.Profile
+import Control.Effect.Time
 import Control.Monad (MonadPlus)
 import Control.Monad.Fix
 import Control.Monad.IO.Class
@@ -44,7 +45,7 @@ execProfile = execWriter . runProfileC
 newtype ProfileC m a = ProfileC { runProfileC :: WriterC Timings m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
-instance Has (Lift IO) sig m => Algebra (Profile :+: sig) (ProfileC m) where
+instance Has (Time Instant) sig m => Algebra (Profile :+: sig) (ProfileC m) where
   alg hdl sig ctx = case sig of
     L (Measure l m) -> do
       start <- now

--- a/fused-effects-profile/src/Control/Carrier/Profile/Tree.hs
+++ b/fused-effects-profile/src/Control/Carrier/Profile/Tree.hs
@@ -48,7 +48,7 @@ newtype ProfileC m a = ProfileC { runProfileC :: WriterC Timings m a }
 instance Has (Time Instant) sig m => Algebra (Profile :+: sig) (ProfileC m) where
   alg hdl sig ctx = case sig of
     L (Measure l m) -> do
-      (duration, (sub, a)) <- time (ProfileC (censor @Timings (const mempty) (listen (runProfileC (hdl (m <$ ctx))))))
+      (sub, (duration, a)) <- ProfileC (censor @Timings (const mempty) (listen (runProfileC (time (hdl (m <$ ctx))))))
       a <$ ProfileC (tell (timing l duration sub))
     R other         -> ProfileC (alg (runProfileC . hdl) (R other) ctx)
     where

--- a/fused-effects-profile/src/Data/Timing.hs
+++ b/fused-effects-profile/src/Data/Timing.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
@@ -15,21 +14,19 @@ module Data.Timing
 , renderTimings
 , reportTimings
 , Instant
-, since
 , Duration(..)
+, since
 ) where
 
 import           Control.Carrier.Time.System
 import           Control.Effect.Lift
 import           Data.Coerce
-import           Data.Fixed
 import qualified Data.HashMap.Strict as HashMap
 import           Data.List (sortOn)
 import           Data.Ord (Down(..))
 import           Data.Text (Text, pack)
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
-import           Data.Time.Clock.System
 import           Numeric (showFFloat)
 import           Prelude hiding (lookup)
 import           System.IO (stderr)
@@ -97,12 +94,3 @@ renderTimings (Timings ts) = vsep (map go (sortOn (Down . mean . snd) (HashMap.t
 
 reportTimings :: Has (Lift IO) sig m => Timings -> m ()
 reportTimings = sendM . renderIO stderr . layoutPretty defaultLayoutOptions . (<> line) . renderTimings
-
-
-since :: Instant -> Instant -> Duration
-since (MkSystemTime bs bns) (MkSystemTime as ans) = Duration (realToFrac (as - bs) + MkFixed (fromIntegral ans - fromIntegral bns))
-{-# INLINABLE since #-}
-
-
-newtype Duration = Duration { getDuration :: Nano }
-  deriving (Eq, Fractional, Num, Ord, Real, Show)

--- a/fused-effects-profile/src/Data/Timing.hs
+++ b/fused-effects-profile/src/Data/Timing.hs
@@ -14,10 +14,9 @@ module Data.Timing
 , lookup
 , renderTimings
 , reportTimings
-, Instant(..)
+, Instant
 , since
 , Duration(..)
-, now
 ) where
 
 import           Control.Effect.Lift
@@ -99,17 +98,12 @@ reportTimings :: Has (Lift IO) sig m => Timings -> m ()
 reportTimings = sendM . renderIO stderr . layoutPretty defaultLayoutOptions . (<> line) . renderTimings
 
 
-newtype Instant = Instant { getInstant :: SystemTime }
-  deriving (Eq, Ord, Show)
+type Instant = SystemTime
 
 since :: Instant -> Instant -> Duration
-since (Instant (MkSystemTime bs bns)) (Instant (MkSystemTime as ans)) = Duration (realToFrac (as - bs) + MkFixed (fromIntegral ans - fromIntegral bns))
+since (MkSystemTime bs bns) (MkSystemTime as ans) = Duration (realToFrac (as - bs) + MkFixed (fromIntegral ans - fromIntegral bns))
 {-# INLINABLE since #-}
 
 
 newtype Duration = Duration { getDuration :: Nano }
   deriving (Eq, Fractional, Num, Ord, Real, Show)
-
-now :: Has (Lift IO) sig m => m Instant
-now = Instant <$> sendIO getSystemTime
-{-# INLINABLE now #-}

--- a/fused-effects-profile/src/Data/Timing.hs
+++ b/fused-effects-profile/src/Data/Timing.hs
@@ -19,6 +19,7 @@ module Data.Timing
 , Duration(..)
 ) where
 
+import           Control.Carrier.Time.System
 import           Control.Effect.Lift
 import           Data.Coerce
 import           Data.Fixed
@@ -97,8 +98,6 @@ renderTimings (Timings ts) = vsep (map go (sortOn (Down . mean . snd) (HashMap.t
 reportTimings :: Has (Lift IO) sig m => Timings -> m ()
 reportTimings = sendM . renderIO stderr . layoutPretty defaultLayoutOptions . (<> line) . renderTimings
 
-
-type Instant = SystemTime
 
 since :: Instant -> Instant -> Duration
 since (MkSystemTime bs bns) (MkSystemTime as ans) = Duration (realToFrac (as - bs) + MkFixed (fromIntegral ans - fromIntegral bns))

--- a/fused-effects-time/LICENSE
+++ b/fused-effects-time/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2020, Rob Rix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/fused-effects-time/README.md
+++ b/fused-effects-time/README.md
@@ -1,0 +1,1 @@
+# `fused-effects-time`

--- a/fused-effects-time/Setup.hs
+++ b/fused-effects-time/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/fused-effects-time/fused-effects-time.cabal
+++ b/fused-effects-time/fused-effects-time.cabal
@@ -1,0 +1,41 @@
+cabal-version:       2.2
+
+name:                fused-effects-time
+version:             0.0.0.0
+synopsis:            Timing via fused-effects.
+description:         Time measurement via fused-effects.
+homepage:            https://github.com/fused-effects/fused-effects-profile/tree/master/fused-effects-time
+bug-reports:         https://github.com/fused-effects/fused-effects-profile/issues
+license:             BSD-3-Clause
+license-file:        LICENSE
+author:              Rob Rix
+maintainer:          rob.rix@me.com
+copyright:           2020 Rob Rix
+category:            System
+extra-source-files:
+  CHANGELOG.md
+  README.md
+
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
+
+library
+  import: common
+  hs-source-dirs: src

--- a/fused-effects-time/fused-effects-time.cabal
+++ b/fused-effects-time/fused-effects-time.cabal
@@ -39,3 +39,8 @@ common common
 library
   import: common
   hs-source-dirs: src
+  build-depends:
+    , base >= 4.12 && < 5
+    , fused-effects ^>= 1.1
+    , time ^>= 1.9
+    , transformers >= 0.4 && < 0.6

--- a/fused-effects-time/fused-effects-time.cabal
+++ b/fused-effects-time/fused-effects-time.cabal
@@ -40,6 +40,7 @@ library
   import: common
   hs-source-dirs: src
   exposed-modules:
+    Control.Carrier.Time.System
     Control.Effect.Time
   build-depends:
     , base >= 4.12 && < 5

--- a/fused-effects-time/fused-effects-time.cabal
+++ b/fused-effects-time/fused-effects-time.cabal
@@ -39,6 +39,8 @@ common common
 library
   import: common
   hs-source-dirs: src
+  exposed-modules:
+    Control.Effect.Time
   build-depends:
     , base >= 4.12 && < 5
     , fused-effects ^>= 1.1

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -1,0 +1,2 @@
+module Control.Carrier.Time.System
+() where

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -1,2 +1,6 @@
 module Control.Carrier.Time.System
-() where
+( -- * Time carrier
+  TimeC(..)
+) where
+
+newtype TimeC m a = TimeC { runTime :: m a }

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -1,4 +1,9 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Control.Carrier.Time.System
 ( -- * Time carrier
   TimeC(..)
@@ -6,12 +11,15 @@ module Control.Carrier.Time.System
 , module Control.Effect.Time
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative)
+import Control.Carrier.Lift
 import Control.Effect.Time
 import Control.Monad (MonadPlus)
 import Control.Monad.Fix (MonadFix)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Class (MonadTrans(..))
+import Data.Time.Clock.System
 
 newtype TimeC m a = TimeC { runTime :: m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
@@ -19,3 +27,9 @@ newtype TimeC m a = TimeC { runTime :: m a }
 instance MonadTrans TimeC where
   lift = TimeC
   {-# INLINE lift #-}
+
+instance Has (Lift IO) sig m => Algebra (Time SystemTime :+: sig) (TimeC m) where
+  alg hdl sig ctx = case sig of
+    L Now   -> (<$ ctx) <$> sendIO getSystemTime
+    R other -> TimeC (alg (runTime . hdl) other ctx)
+  {-# INLINE alg #-}

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -18,3 +18,4 @@ newtype TimeC m a = TimeC { runTime :: m a }
 
 instance MonadTrans TimeC where
   lift = TimeC
+  {-# INLINE lift #-}

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -7,6 +7,8 @@
 module Control.Carrier.Time.System
 ( -- * Time carrier
   Instant
+, Duration(..)
+, since
 , TimeC(..)
   -- * Time effect
 , module Control.Effect.Time
@@ -20,9 +22,18 @@ import Control.Monad (MonadPlus)
 import Control.Monad.Fix (MonadFix)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Class (MonadTrans(..))
+import Data.Fixed
 import Data.Time.Clock.System
 
 type Instant = SystemTime
+
+newtype Duration = Duration { getDuration :: Nano }
+  deriving (Eq, Fractional, Num, Ord, Real, Show)
+
+
+since :: Instant -> Instant -> Duration
+since (MkSystemTime bs bns) (MkSystemTime as ans) = Duration (realToFrac (as - bs) + MkFixed (fromIntegral ans - fromIntegral bns))
+{-# INLINABLE since #-}
 
 
 newtype TimeC m a = TimeC { runTime :: m a }

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -30,12 +30,6 @@ instance MonadTrans TimeC where
 
 instance Has (Lift IO) sig m => Algebra (Time SystemTime :+: sig) (TimeC m) where
   alg hdl sig ctx = case sig of
-    L Now            -> (<$ ctx) <$> sendIO getSystemTime
-    L (TimeWith f m) -> do
-      start <- sendIO getSystemTime
-      a <- hdl (m <$ ctx)
-      end <- sendIO getSystemTime
-      let d = f start end
-      d `seq` pure ((,) d <$> a)
-    R other          -> TimeC (alg (runTime . hdl) other ctx)
+    L Now   -> (<$ ctx) <$> sendIO getSystemTime
+    R other -> TimeC (alg (runTime . hdl) other ctx)
   {-# INLINE alg #-}

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -30,6 +30,12 @@ instance MonadTrans TimeC where
 
 instance Has (Lift IO) sig m => Algebra (Time SystemTime :+: sig) (TimeC m) where
   alg hdl sig ctx = case sig of
-    L Now   -> (<$ ctx) <$> sendIO getSystemTime
-    R other -> TimeC (alg (runTime . hdl) other ctx)
+    L Now            -> (<$ ctx) <$> sendIO getSystemTime
+    L (TimeWith f m) -> do
+      start <- sendIO getSystemTime
+      a <- hdl (m <$ ctx)
+      end <- sendIO getSystemTime
+      let d = f start end
+      d `seq` pure ((,) d <$> a)
+    R other          -> TimeC (alg (runTime . hdl) other ctx)
   {-# INLINE alg #-}

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Control.Carrier.Time.System
 ( -- * Time carrier
   TimeC(..)
@@ -5,6 +6,11 @@ module Control.Carrier.Time.System
 , module Control.Effect.Time
 ) where
 
+import Control.Applicative (Alternative)
 import Control.Effect.Time
+import Control.Monad (MonadPlus)
+import Control.Monad.Fix (MonadFix)
+import Control.Monad.IO.Class (MonadIO)
 
 newtype TimeC m a = TimeC { runTime :: m a }
+  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -6,7 +6,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Control.Carrier.Time.System
 ( -- * Time carrier
-  TimeC(..)
+  Instant
+, TimeC(..)
   -- * Time effect
 , module Control.Effect.Time
 ) where
@@ -20,6 +21,9 @@ import Control.Monad.Fix (MonadFix)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Data.Time.Clock.System
+
+type Instant = SystemTime
+
 
 newtype TimeC m a = TimeC { runTime :: m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -1,6 +1,10 @@
 module Control.Carrier.Time.System
 ( -- * Time carrier
   TimeC(..)
+  -- * Time effect
+, module Control.Effect.Time
 ) where
+
+import Control.Effect.Time
 
 newtype TimeC m a = TimeC { runTime :: m a }

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -11,6 +11,10 @@ import Control.Effect.Time
 import Control.Monad (MonadPlus)
 import Control.Monad.Fix (MonadFix)
 import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans.Class (MonadTrans(..))
 
 newtype TimeC m a = TimeC { runTime :: m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
+
+instance MonadTrans TimeC where
+  lift = TimeC

--- a/fused-effects-time/src/Control/Carrier/Time/System.hs
+++ b/fused-effects-time/src/Control/Carrier/Time/System.hs
@@ -9,6 +9,7 @@ module Control.Carrier.Time.System
   Instant
 , Duration(..)
 , since
+, time
 , TimeC(..)
   -- * Time effect
 , module Control.Effect.Time
@@ -34,6 +35,10 @@ newtype Duration = Duration { getDuration :: Nano }
 since :: Instant -> Instant -> Duration
 since (MkSystemTime bs bns) (MkSystemTime as ans) = Duration (realToFrac (as - bs) + MkFixed (fromIntegral ans - fromIntegral bns))
 {-# INLINABLE since #-}
+
+time :: Has (Time Instant) sig m => m a -> m (Duration, a)
+time = timeWith since
+{-# INLINE time #-}
 
 
 newtype TimeC m a = TimeC { runTime :: m a }

--- a/fused-effects-time/src/Control/Effect/Time.hs
+++ b/fused-effects-time/src/Control/Effect/Time.hs
@@ -1,0 +1,2 @@
+module Control.Effect.Time
+() where

--- a/fused-effects-time/src/Control/Effect/Time.hs
+++ b/fused-effects-time/src/Control/Effect/Time.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 module Control.Effect.Time
 ( -- * Time effect
   now
@@ -11,6 +12,7 @@ module Control.Effect.Time
 ) where
 
 import Control.Algebra
+import Data.Kind (Type)
 
 now :: Has (Time instant) sig m => m instant
 now = send Now
@@ -20,6 +22,6 @@ timeWith :: Has (Time instant) sig m => (instant -> instant -> delta) -> m a -> 
 timeWith with m = send (TimeWith with m)
 {-# INLINE timeWith #-}
 
-data Time instant m k where
+data Time instant (m :: Type -> Type) k where
   Now      ::                                         Time instant m instant
   TimeWith :: (instant -> instant -> delta) -> m a -> Time instant m (delta, a)

--- a/fused-effects-time/src/Control/Effect/Time.hs
+++ b/fused-effects-time/src/Control/Effect/Time.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
 module Control.Effect.Time
 ( -- * Time effect
   now
@@ -12,7 +11,6 @@ module Control.Effect.Time
 ) where
 
 import Control.Algebra
-import Data.Kind (Type)
 
 now :: Has (Time instant) sig m => m instant
 now = send Now
@@ -22,6 +20,6 @@ timeWith :: Has (Time instant) sig m => (instant -> instant -> delta) -> m a -> 
 timeWith with m = send (TimeWith with m)
 {-# INLINE timeWith #-}
 
-data Time instant (m :: Type -> Type) k where
+data Time instant m k where
   Now      ::                                         Time instant m instant
   TimeWith :: (instant -> instant -> delta) -> m a -> Time instant m (delta, a)

--- a/fused-effects-time/src/Control/Effect/Time.hs
+++ b/fused-effects-time/src/Control/Effect/Time.hs
@@ -2,10 +2,15 @@
 {-# LANGUAGE KindSignatures #-}
 module Control.Effect.Time
 ( -- * Time effect
-  Time(..)
+  now
+, Time(..)
 ) where
 
+import Control.Algebra
 import Data.Kind (Type)
+
+now :: Has (Time instant) sig m => m instant
+now = send Now
 
 data Time instant (m :: Type -> Type) k where
   Now :: Time instant m instant

--- a/fused-effects-time/src/Control/Effect/Time.hs
+++ b/fused-effects-time/src/Control/Effect/Time.hs
@@ -3,7 +3,6 @@
 module Control.Effect.Time
 ( -- * Time effect
   now
-, timeWith
 , Time(..)
   -- * Re-exports
 , Algebra
@@ -18,10 +17,5 @@ now :: Has (Time instant) sig m => m instant
 now = send Now
 {-# INLINE now #-}
 
-timeWith :: Has (Time instant) sig m => (instant -> instant -> delta) -> m a -> m (delta, a)
-timeWith with m = send (TimeWith with m)
-{-# INLINE timeWith #-}
-
 data Time instant (m :: Type -> Type) k where
-  Now      ::                                         Time instant m instant
-  TimeWith :: (instant -> instant -> delta) -> m a -> Time instant m (delta, a)
+  Now :: Time instant m instant

--- a/fused-effects-time/src/Control/Effect/Time.hs
+++ b/fused-effects-time/src/Control/Effect/Time.hs
@@ -4,6 +4,10 @@ module Control.Effect.Time
 ( -- * Time effect
   now
 , Time(..)
+  -- * Re-exports
+, Algebra
+, Has
+, run
 ) where
 
 import Control.Algebra

--- a/fused-effects-time/src/Control/Effect/Time.hs
+++ b/fused-effects-time/src/Control/Effect/Time.hs
@@ -3,6 +3,7 @@
 module Control.Effect.Time
 ( -- * Time effect
   now
+, timeWith
 , Time(..)
   -- * Re-exports
 , Algebra
@@ -17,5 +18,10 @@ now :: Has (Time instant) sig m => m instant
 now = send Now
 {-# INLINE now #-}
 
+timeWith :: Has (Time instant) sig m => (instant -> instant -> delta) -> m a -> m (delta, a)
+timeWith with m = send (TimeWith with m)
+{-# INLINE timeWith #-}
+
 data Time instant (m :: Type -> Type) k where
-  Now :: Time instant m instant
+  Now      ::                                         Time instant m instant
+  TimeWith :: (instant -> instant -> delta) -> m a -> Time instant m (delta, a)

--- a/fused-effects-time/src/Control/Effect/Time.hs
+++ b/fused-effects-time/src/Control/Effect/Time.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 module Control.Effect.Time
 ( -- * Time effect
   Time(..)
 ) where
 
-data Time instant m k where
+import Data.Kind (Type)
+
+data Time instant (m :: Type -> Type) k where
   Now :: Time instant m instant

--- a/fused-effects-time/src/Control/Effect/Time.hs
+++ b/fused-effects-time/src/Control/Effect/Time.hs
@@ -3,6 +3,7 @@
 module Control.Effect.Time
 ( -- * Time effect
   now
+, timeWith
 , Time(..)
   -- * Re-exports
 , Algebra
@@ -16,6 +17,15 @@ import Data.Kind (Type)
 now :: Has (Time instant) sig m => m instant
 now = send Now
 {-# INLINE now #-}
+
+timeWith :: Has (Time instant) sig m => (instant -> instant -> delta) -> m a -> m (delta, a)
+timeWith with m = do
+  start <- now
+  a <- m
+  end <- now
+  let d = with start end
+  d `seq` pure (d, a)
+{-# INLINE timeWith #-}
 
 data Time instant (m :: Type -> Type) k where
   Now :: Time instant m instant

--- a/fused-effects-time/src/Control/Effect/Time.hs
+++ b/fused-effects-time/src/Control/Effect/Time.hs
@@ -1,2 +1,8 @@
+{-# LANGUAGE GADTs #-}
 module Control.Effect.Time
-() where
+( -- * Time effect
+  Time(..)
+) where
+
+data Time instant m k where
+  Now :: Time instant m instant

--- a/fused-effects-time/src/Control/Effect/Time.hs
+++ b/fused-effects-time/src/Control/Effect/Time.hs
@@ -15,6 +15,7 @@ import Data.Kind (Type)
 
 now :: Has (Time instant) sig m => m instant
 now = send Now
+{-# INLINE now #-}
 
 data Time instant (m :: Type -> Type) k where
   Now :: Time instant m instant

--- a/script/ghci-flags
+++ b/script/ghci-flags
@@ -22,6 +22,7 @@ function flags {
   echo "-stubdir $build_products_dir"
 
   echo "-ifused-effects-profile/src"
+  echo "-ifused-effects-time/src"
 
   echo "-hide-all-packages"
 

--- a/script/ghci-flags-dependencies
+++ b/script/ghci-flags-dependencies
@@ -8,3 +8,4 @@ cd $(dirname "$0")/..
 echo "cabal.project"
 
 echo "fused-effects-profile/fused-effects-profile.cabal"
+echo "fused-effects-time/fused-effects-time.cabal"


### PR DESCRIPTION
This PR extracts the timing mechanisms into a new `fused-effects-time` package (in this same repo).

- [x] Fixes #7.